### PR TITLE
Validação de ano com restrições redundantes

### DIFF
--- a/src/creditCard.js
+++ b/src/creditCard.js
@@ -48,7 +48,7 @@ class CreditCard {
     let y = year;
     let yearLength = y.length;
 
-    if (yearLength < 2 && yearLength > 4)
+    if (yearLength  != 2 && yearLength != 4)
       return false;
 
     m = parseInt(m, 10);

--- a/src/creditCard.js
+++ b/src/creditCard.js
@@ -48,7 +48,7 @@ class CreditCard {
     let y = year;
     let yearLength = y.length;
 
-    if (yearLength  != 2 && yearLength != 4)
+    if (yearLength != 4)
       return false;
 
     m = parseInt(m, 10);

--- a/src/creditCard.js
+++ b/src/creditCard.js
@@ -48,7 +48,7 @@ class CreditCard {
     let y = year;
     let yearLength = y.length;
 
-    if (yearLength != 4)
+    if (yearLength !== 4)
       return false;
 
     m = parseInt(m, 10);


### PR DESCRIPTION
Basicamente a antiga validação verificava se o `length` do ano informado era **inferior a 2 ou superior a 4** ou seja isso restringia o `length` data especificada em `2,3,4`, vide bloco abaixo:
``` js
if (yearLength < 2 && yearLength > 4)
```
Considerando que qualquer ano com data inferior a 1000 e superior a 3000 vai retornar false por causa da validação abaixo:

``` js
return !(y < 1000 || y >= 3000);
```
Os seguintes exemplos de parâmetros inválidos passariam por todo o processamento do método até serem restringidos na última validação:

**"10"**,  length = 2 // Qualquer outro número com length 2 também apresentaria o mesmo problema 
**"200"**, length = 3 // Qualquer outro número com length 3 também apresentaria o mesmo problema 

Teríamos o custo de dar cast nos dados e proceder com as demais validações porque a primeira não está restringindo os dados em conjunto com as demais validações.
