### PR TITLE
Improve security code check

### DIFF
--- a/src/creditCard.js
+++ b/src/creditCard.js
@@ -38,9 +38,9 @@ class CreditCard {
     let numberLength;
 
     numberLength = (brand === 'Amex') ? 4 : 3;
-    let regex = new RegExp(`[0-9]{${numberLength}}`);
+    let regex = new RegExp(`^[0-9]{${numberLength}}$`);
 
-    return (code.length === numberLength && regex.test(code));
+    return regex.test(code);
   }
 
   isExpirationDateValid(month, year) {


### PR DESCRIPTION
Using anchors in the regex, you can avoid partial matches (the old regex would match `foo1234bar`) and in this case, restrict the match to a fixed number of digits, making the `code.length` test redundant.