### PR TITLE
Remove redundant check

### DIFF
--- a/src/creditCard.js
+++ b/src/creditCard.js
@@ -46,7 +46,6 @@ class CreditCard {
   isExpirationDateValid(month, year) {
     let m = month;
     let y = year;
-    let yearLength = y.length;
 
     m = parseInt(m, 10);
     y = parseInt(y, 10);

--- a/src/creditCard.js
+++ b/src/creditCard.js
@@ -48,9 +48,6 @@ class CreditCard {
     let y = year;
     let yearLength = y.length;
 
-    if (yearLength !== 4)
-      return false;
-
     m = parseInt(m, 10);
     y = parseInt(y, 10);
 


### PR DESCRIPTION
This check is redundant, since there is already the limit between 1000 and 3000 for the year at the funtion `return`.