### PR TITLE
Fix automatic NPM package publishing

### DIFF
--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -40,15 +40,14 @@ jobs:
       # Build the project
       - name: Build
         run: yarn build
-      
+
       # Authenticate to NPM
       - name: Authenticate with Registry
         run: |
-          echo "registry=http://registry.npmjs.org/" > .npmrc
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> .npmrc
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
 
-      # release and publish version
+      # Release and publish version
       - name: Release version
-        run: yarn release --ci
+        run: yarn release --ci --npm.skipChecks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### What is the change?

Add `--npm.skipChecks` to `release-it` on release job in Actions.

Following release-it docs:
https://github.com/release-it/release-it/blob/master/docs/ci.md#npm

### Why make this change?

Fixing error on publish package to NPM by Actions