### PR TITLE
fix: card number length validation

### DIFF
--- a/src/creditcard.js
+++ b/src/creditcard.js
@@ -21,30 +21,47 @@ export const isExpirationDateValid = (month, year) => {
 };
 
 export const isValid = (number, options = {}) => {
-  const invalidDigits = new RegExp('[^0-9- ]');
   const { cards } = options;
+  const rawNumber = removeNonNumbersCaracteres(number);
 
-  if (invalidDigits.test(number)) return false;
-
-  const rawNumber = number.replace(/\D/g, '');
-
-  if (rawNumber.length <= 19) return false;
-
-  const sum = sumNumber(rawNumber);
-  const sumIsOk = sum > 0 && sum % 10 === 0;
-
-  if (cards && cards.length) {
-    return (
-      sumIsOk &&
-      areCardsSupported(cards) &&
-      cards
-        .map((c) => c.toLowerCase())
-        .includes(getCreditCardNameByNumber(number).toLowerCase())
-    );
+  if (hasSomeInvalidDigit(number) || !hasCorrectLength(rawNumber)) {
+    return false;
   }
 
-  return sumIsOk;
+  const sum = sumNumber(rawNumber);
+
+  return checkSum(sum) && validateCardsWhenRequired(number, cards);
 };
+
+function validateCardsWhenRequired(number, cards) {
+  return !cards || !cards.length || validateCards(number, cards);
+}
+
+function validateCards(number, cards) {
+  return (
+    areCardsSupported(cards) &&
+    cards
+      .map((c) => c.toLowerCase())
+      .includes(getCreditCardNameByNumber(number).toLowerCase())
+  );
+}
+
+function hasCorrectLength(number) {
+  return number && number.length <= 19;
+}
+
+function removeNonNumbersCaracteres(number) {
+  return number.replace(/\D/g, '');
+}
+
+function hasSomeInvalidDigit(creditcardNumber) {
+  const invalidDigits = new RegExp('[^0-9- ]');
+  return invalidDigits.test(creditcardNumber);
+}
+
+function checkSum(sum) {
+  return sum > 0 && sum % 10 === 0;
+}
 
 function areCardsSupported(passedCards) {
   const supportedCards = CARDS.map((c) => c.name.toLowerCase());

--- a/src/creditcard.js
+++ b/src/creditcard.js
@@ -26,7 +26,11 @@ export const isValid = (number, options = {}) => {
 
   if (invalidDigits.test(number)) return false;
 
-  const sum = sumNumber(number.replace(/\D/g, ''));
+  const rawNumber = number.replace(/\D/g, '');
+
+  if (rawNumber.length <= 19) return false;
+
+  const sum = sumNumber(rawNumber);
   const sumIsOk = sum > 0 && sum % 10 === 0;
 
   if (cards && cards.length) {

--- a/src/creditcard.test.js
+++ b/src/creditcard.test.js
@@ -200,6 +200,14 @@ describe('CreditCard', () => {
       ).toBeFalsy();
     });
 
+    it('should return false when two valid credit card numbers are concatenated', () => {
+      expect(isValid('40128888888818815500000000000004')).toBe(false);
+    });
+
+    it('should return false when length is greater than 16', () => {
+      expect(isValid('40128888888818811351')).toBe(false);
+    });
+
     it('should return true when its a VALID credit card number with spaces', () => {
       expect(isValid('40128 88888 88188 1')).toBeTruthy();
     });

--- a/src/creditcard.test.js
+++ b/src/creditcard.test.js
@@ -204,7 +204,7 @@ describe('CreditCard', () => {
       expect(isValid('40128888888818815500000000000004')).toBe(false);
     });
 
-    it('should return false when length is greater than 16', () => {
+    it('should return false when length is greater than 19', () => {
       expect(isValid('40128888888818811351')).toBe(false);
     });
 


### PR DESCRIPTION
### What is the change?
* Add length validation. 

### Why make this change?
resolves https://github.com/ContaAzul/creditcard.js/issues/131

The credit card number length has a maximum value of 19, which is enough to fix this bug.

#### Sources 

https://en.wikipedia.org/wiki/Payment_card_number#Issuer_identification_number_(IIN)

https://www.discoverglobalnetwork.com/downloads/IPP_VAR_Compliance.pdf

### Test plan
