### PR TITLE
fix: fixing isValid method

### DIFF
--- a/src/creditcard.js
+++ b/src/creditcard.js
@@ -2,6 +2,7 @@ import CARDS from './cards';
 
 const MILLENNIUM = 1000;
 const DEFAULT_CODE_LENGTH = 3;
+const CARD_NUMBER_LENGTH = 16;
 
 export const getCreditCardNameByNumber = (number) => {
   return findCreditCardObjectByNumber(number).name || 'Credit card is invalid!';
@@ -47,7 +48,7 @@ function validateCards(number, cards) {
 }
 
 function hasCorrectLength(number) {
-  return number && number.length <= 19;
+  return number && number.length === CARD_NUMBER_LENGTH;
 }
 
 function removeNonNumbersCaracteres(number) {

--- a/src/creditcard.test.js
+++ b/src/creditcard.test.js
@@ -240,6 +240,10 @@ describe('CreditCard', () => {
       expect(isValid('0000000')).toBeFalsy();
     });
 
+    it('should return false when its a INVALID credit card number with a valid checksum', () => {
+      expect(isValid('132423')).toBeFalsy();
+    });
+
     it('should return false when its a INVALID credit card number and contains cards list', () => {
       expect(isValid('0000000', { cards: ['visa'] })).toBeFalsy();
     });


### PR DESCRIPTION
### What is the change?
Fix isValid method  when an invalid card number is passed with a valid checksum

### Why make this change?
In order to fix this issue: https://github.com/ContaAzul/creditcard.js/issues/139

### Test plan
